### PR TITLE
Allow `with_frame` to be called from inside a loop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@ impl<'a> ReportErrorBuilder<'a> {
     }
 
     /// Add a new frame to the collection of stack frames.
-    pub fn with_frame(&'a mut self, frame_builder: FrameBuilder) -> &'a mut Self {
+    pub fn with_frame(&mut self, frame_builder: FrameBuilder) -> &mut Self {
         self.trace.frames.push(frame_builder);
         self
     }


### PR DESCRIPTION
Thank you for providing a Rollbar client library for Rust! This is a very useful thing to have.

We use the `error-trace` library, which provides backtraces for where
the original error occurred.  We wanted to pass these backtraces to
`rollbar`.  But to do this, we needed to call `with_frame` in a loop,
and this failed as follows:

    error[E0499]: cannot borrow `err_builder` as mutable more than once at a time
       --> src/errors.rs:160:21
        |
    160 |                     err_builder.with_frame(fb.build());
        |                     ^^^^^^^^^^^
        |                     |
        |                     second mutable borrow occurs here
        |                     first mutable borrow occurs here
    ...
    166 |     }
        |     - first borrow ends here

    error[E0499]: cannot borrow `err_builder` as mutable more than once at a time
       --> src/errors.rs:164:9
        |
    160 |                     err_builder.with_frame(fb.build());
        |                     ----------- first mutable borrow occurs here
    ...
    164 |         err_builder.send();
        |         ^^^^^^^^^^^ second mutable borrow occurs here
    165 |         Ok(())
    166 |     }
        |     - first borrow ends here

The problem occurs because of a subtle lifetime issue in the function
declaration:

    impl<'a> ReportErrorBuilder<'a> {
        // ...
        pub fn with_frame(&'a mut self, frame_builder: FrameBuilder) -> &'a mut Self {
        // ...
    }

Here, `Self` refers to the type `ReportErrorBuilder<'a>`, which contains
the lifetime `'a`.  But the the `with_frame` function uses a mutable
reference `&'a mut self`, which also includes `'a`. This says that the
_reference_ to `ReportErrorBuilder` has the same lifetime as the
`ReportErrorBuilder` itself, which makes it impossible to use the
function anywhere except in a "fluent" call chain:

    let payload = client.build_report()
        .from_error_message(&e)
        .with_level(Level::WARNING)
        .with_frame(FrameBuilder::new()
                    .with_column_number(42)
                    .build())
        .with_frame(FrameBuilder::new()
                    .with_column_number(24)
                    .build())
        .with_title("w")
        .to_string();

But if we change the signature to:

    pub fn with_frame(&mut self, frame_builder: FrameBuilder) -> &mut Self {

...then Rust will automatically generate a new lifetime (call it `'b`)
for the `&mut` reference.  This will make everything work nicely.  In
this case, Rust's defaults do exactly what you want.

You may also want to apply a similar fix to `with_backtrace`, but I
haven't looked at that yet.