### PR TITLE
Update hyper crates versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Track and report errors, exceptions and messages from your Rust a
 keywords    = ["rollbar", "logging", "errors", "exceptions"]
 
 [dependencies]
-backtrace = "0.3.15"
+backtrace = "0.3"
 
 hyper = "0.12"
 hyper-tls = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ description = "Track and report errors, exceptions and messages from your Rust a
 keywords    = ["rollbar", "logging", "errors", "exceptions"]
 
 [dependencies]
-backtrace = "0.3"
+backtrace = "0.3.15"
 
-hyper = "0.10"
-hyper-openssl = "0.2"
+hyper = "0.12.28"
+hyper-openssl = "0.7.1"
 
-serde = "1.0"
-serde_json = "1.0"
-serde_derive = "1.0"
+serde = "1.0.*"
+serde_json = "1.0.*"
+serde_derive = "1.0.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ keywords    = ["rollbar", "logging", "errors", "exceptions"]
 [dependencies]
 backtrace = "0.3.15"
 
-hyper = "0.12.28"
-hyper-openssl = "0.7.1"
+hyper = "0.12"
+hyper-tls = "0.3"
 
-serde = "1.0.*"
-serde_json = "1.0.*"
-serde_derive = "1.0.*"
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ backtrace = "0.3.15"
 hyper = "0.12"
 hyper-tls = "0.3"
 
+tokio="*"
+futures="*"
+
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,7 +457,7 @@ impl Client {
     /// You can get the `access_token` at
     /// <https://rollbar.com/{your_organization}/{your_app}/settings/access_tokens>.
     pub fn new<T: Into<String>>(access_token: T, environment: T) -> Client {
-        let ssl = hyper_openssl::OpensslClient::new().unwrap();
+        let ssl = hyper_openssl::HttpsConnector::new().unwrap();
         let connector = hyper::net::HttpsConnector::new(ssl);
 
         Client {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -767,11 +767,10 @@ mod tests {
             .with_level("info")
             .send();
 
-        println!("Status handle: {:?}", status_handle);
         match status_handle.join().unwrap() {
             Some(status) => {
                 assert_eq!(status.to_string(),
-                           "Error 401 Unauthorized: No access token was found in the request.".to_owned());
+                    "Error 401 Unauthorized: No access token was found in the request.".to_owned());
             }
             None => { assert!(false); }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #[macro_use] extern crate serde_derive;
 extern crate serde;
 extern crate hyper;
-extern crate hyper_openssl;
+extern crate hyper_tls;
 extern crate backtrace;
 
 use std::{thread, fmt, panic, error};
@@ -132,7 +132,7 @@ const URL: &'static str = "https://api.rollbar.com/api/1/item/";
 /// Builder for a generic request to Rollbar.
 pub struct ReportBuilder<'a> {
     client: &'a Client,
-    send_strategy: Option<Box<Fn(Arc<hyper::Client>, String) -> thread::JoinHandle<Option<ResponseStatus>>>>
+    send_strategy: Option<Box<Fn(Arc<hyper::Client<hyper_openssl::HttpsConnector<hyper::HttpConnector>>>, String) -> thread::JoinHandle<Option<ResponseStatus>>>>
 }
 
 /// Wrapper for a trace, payload of a single exception.
@@ -443,7 +443,7 @@ impl<'a> ReportBuilder<'a> {
 
 /// The access point to the library.
 pub struct Client {
-    http_client: Arc<hyper::Client>,
+    http_client: Arc<hyper::Client<hyper_openssl::HttpsConnector<hyper::HttpConnector>>>,
     access_token: String,
     environment: String
 }


### PR DESCRIPTION
Adding `rollbar = "0.5.1"` crate to Cargo.toml makes project fail to compile

## Error
```
klastovirya [~/Projects/rust-buildpack-example-actix] at  add-rollbar-error-reporting !
→ cargo build                                                                                              [07d48fc]
    Blocking waiting for file lock on the registry index
    Updating crates.io index
   Compiling openssl v0.9.24
   Compiling tokio-io v0.1.12
   Compiling serde_derive v1.0.91
   Compiling tokio-threadpool v0.1.14
error: failed to run custom build command for `openssl v0.9.24`
process didn't exit successfully: `/Users/klastovirya/Projects/rust-buildpack-example-actix/target/debug/build/openssl-42343e84315ca446/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'Unable to detect OpenSSL version', /Users/klastovirya/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.9.24/build.rs:16:14
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

## Cause
from here https://github.com/paritytech/substrate/issues/800

the problem is my openssl version is 1.1.1
it is not supported by
0.9.x of openssl crate :
https://github.com/sfackler/rust-openssl/blob/0.9.x/openssl/build.rs#L16
the problem is fixed in newer version of openssl crate :
https://github.com/sfackler/rust-openssl/blob/master/openssl/build.rs#L33

## Solution
Use the last version of the hyper crate. Replace hyper-openssl crate with hyper-tls. 