### PR TITLE
Chain the existing panic_hook onto Rollbar reporting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "rollbar"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Giovanni Capuano <webmaster@giovannicapuano.net"]
 
 repository  = "https://github.com/RoxasShadow/rollbar-rs"


### PR DESCRIPTION
Currently the macro `report_panics!` works just fine, but it replaces the default `panic hook`.

This causes a number of issues:

1. No feedback on the console once `rollbar` is enabled, which is the default expected behaviour for `panic!`
2. A custom `panic_hook` that is in place before `rollbar` is called will no longer be called

This PR fixes that by chaining the original panic hook on the end of rollbar reporting.